### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/update-better-sqlite3.yml
+++ b/.github/workflows/update-better-sqlite3.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Get latest release info
         id: release
@@ -117,7 +117,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.download.outputs.has_updates == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update better-sqlite3-multiple-ciphers to ${{ steps.release.outputs.version }}"

--- a/.github/workflows/update-db2-binaries.yml
+++ b/.github/workflows/update-db2-binaries.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Get VS Code Electron version
         id: vscode_electron
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.package.outputs.has_updates == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Add new DB2 ODBC binaries"


### PR DESCRIPTION
Pins both binary-update workflows to full commit SHAs (tag in trailing comment so Dependabot can still bump):

- `actions/checkout` v4 -> **v6.0.3** (`df4cb1c`) - also clears the Node 20 runner deprecation.
- `peter-evans/create-pull-request` v8 -> **v8.1.1** (`5f6978f`).

Tags can be retargeted; SHAs can't.