### PR TITLE
ci: build patched SQLite prebuilds for new Electron (Linux/Windows)

### DIFF
--- a/.github/scripts/patch-bsmc-v8-14.js
+++ b/.github/scripts/patch-bsmc-v8-14.js
@@ -1,0 +1,85 @@
+/**
+ * Applies the V8 14 / Electron 42 (ABI 146) build fix to a better-sqlite3-multiple-ciphers
+ * source tree (the WiseLibs/better-sqlite3 #1475 fix, ported to the multiple-ciphers fork).
+ *
+ * V8 14 made v8::External::New()/Value() require an ExternalPointerTypeTag and made
+ * ObjectTemplate::SetNativeDataProperty's 4th arg ambiguous for the literal 0. Without this,
+ * the addon does not compile against Electron 42 / Node 24 headers.
+ *
+ * Usage: node patch-bsmc-v8-14.js <path-to-extracted-package-dir>
+ * Idempotent; exits non-zero if any anchor is missing (source layout changed upstream).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const pkg = process.argv[2];
+if (!pkg) {
+	console.error('Usage: node patch-bsmc-v8-14.js <package-dir>');
+	process.exit(2);
+}
+
+let failed = false;
+
+function replaceOnce(rel, oldStr, newStr, label) {
+	const file = path.join(pkg, rel);
+	let c = fs.readFileSync(file, 'utf8');
+	if (c.includes(newStr) && !c.includes(oldStr)) {
+		console.log(`SKIP (already patched) ${rel}: ${label}`);
+		return;
+	}
+	if (!c.includes(oldStr)) {
+		console.error(`MISSING ANCHOR ${rel}: ${label}`);
+		failed = true;
+		return;
+	}
+	fs.writeFileSync(file, c.replace(oldStr, newStr));
+	console.log(`OK ${rel}: ${label}`);
+}
+
+// 1) better_sqlite3.cpp - route External::New through the gated macro
+replaceOnce(
+	'src/better_sqlite3.cpp',
+	'v8::External::New(isolate, addon)',
+	'EXTERNAL_NEW(isolate, addon)',
+	'External::New -> EXTERNAL_NEW',
+);
+
+// 2) macros.cpp - define the ABI-gated macros and route OnlyAddon through EXTERNAL_VALUE
+replaceOnce(
+	'src/util/macros.cpp',
+	'#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())',
+	'#if defined(NODE_MODULE_VERSION) && NODE_MODULE_VERSION >= 146\n' +
+		'#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value), 0)\n' +
+		'#define EXTERNAL_VALUE(value) (value)->Value(0)\n' +
+		'#else\n' +
+		'#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value))\n' +
+		'#define EXTERNAL_VALUE(value) (value)->Value()\n' +
+		'#endif\n' +
+		'#define OnlyAddon static_cast<Addon*>(EXTERNAL_VALUE(info.Data().As<v8::External>()))',
+	'OnlyAddon + EXTERNAL_NEW/EXTERNAL_VALUE macros',
+);
+
+// 3) helpers.cpp - SetNativeDataProperty 4th arg 0 -> nullptr (disambiguates the overload).
+//    Source ships CRLF; accept either line ending.
+{
+	const file = path.join(pkg, 'src/util/helpers.cpp');
+	let c = fs.readFileSync(file, 'utf8');
+	const crlf = '\t\tfunc,\r\n\t\t0,\r\n\t\tdata';
+	const lf = '\t\tfunc,\n\t\t0,\n\t\tdata';
+	if (c.includes('\t\tfunc,\r\n\t\tnullptr,') || c.includes('\t\tfunc,\n\t\tnullptr,')) {
+		console.log('SKIP (already patched) src/util/helpers.cpp: SetNativeDataProperty');
+	} else if (c.includes(crlf)) {
+		fs.writeFileSync(file, c.replace(crlf, '\t\tfunc,\r\n\t\tnullptr,\r\n\t\tdata'));
+		console.log('OK src/util/helpers.cpp: SetNativeDataProperty');
+	} else if (c.includes(lf)) {
+		fs.writeFileSync(file, c.replace(lf, '\t\tfunc,\n\t\tnullptr,\n\t\tdata'));
+		console.log('OK src/util/helpers.cpp: SetNativeDataProperty');
+	} else {
+		console.error('MISSING ANCHOR src/util/helpers.cpp: SetNativeDataProperty');
+		failed = true;
+	}
+}
+
+if (failed) {
+	process.exit(1);
+}

--- a/.github/scripts/verify-bsmc.js
+++ b/.github/scripts/verify-bsmc.js
@@ -1,0 +1,63 @@
+/**
+ * Runtime verification for a built better-sqlite3-multiple-ciphers binary, run UNDER ELECTRON
+ * (so process.versions.modules reflects the Electron ABI, e.g. 146 for Electron 42).
+ *
+ * Usage: electron verify-bsmc.js <path-to-package-dir>
+ * Prints "VERIFY_OK {...}" and exits 0 on success, "VERIFY_FAIL ..." and exits 1 otherwise.
+ */
+const { app } = require('electron');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+app.disableHardwareAcceleration?.();
+app.commandLine.appendSwitch('no-sandbox');
+
+app.whenReady().then(() => {
+	let encFile;
+	try {
+		const pkgDir = process.argv[2];
+		const Database = require(pkgDir);
+
+		const db = new Database(':memory:');
+		db.exec('CREATE TABLE t(a INTEGER, b TEXT)');
+		db.prepare('INSERT INTO t VALUES (?, ?)').run(42, 'ok');
+		const row = db.prepare('SELECT a, b FROM t WHERE a = ?').get(42);
+		const ver = db.prepare('SELECT sqlite_version() AS v').get();
+		db.close();
+
+		// exercise the multiple-ciphers encryption path on a real file
+		encFile = path.join(os.tmpdir(), `verify_bsmc_${process.pid}.db`);
+		const enc = new Database(encFile);
+		enc.pragma("cipher='sqlcipher'");
+		enc.pragma("key='testkey'");
+		enc.exec('CREATE TABLE s(x)');
+		enc.prepare('INSERT INTO s VALUES (7)').run();
+		const encRow = enc.prepare('SELECT x FROM s').get();
+		enc.close();
+
+		if (row.a !== 42 || row.b !== 'ok' || encRow.x !== 7) {
+			throw new Error(`unexpected result: ${JSON.stringify({ row, encRow })}`);
+		}
+		console.log(
+			'VERIFY_OK ' +
+				JSON.stringify({
+					row,
+					sqlite: ver.v,
+					abi: process.versions.modules,
+					electron: process.versions.electron,
+					node: process.versions.node,
+					encRow,
+				}),
+		);
+		process.exitCode = 0;
+	} catch (e) {
+		console.log('VERIFY_FAIL ' + ((e && e.stack) || e));
+		process.exitCode = 1;
+	} finally {
+		if (encFile && fs.existsSync(encFile)) {
+			fs.unlinkSync(encFile);
+		}
+		app.quit();
+	}
+});

--- a/.github/workflows/build-better-sqlite3-electron.yml
+++ b/.github/workflows/build-better-sqlite3-electron.yml
@@ -1,0 +1,98 @@
+name: Build Better-SQLite3 (patched, Electron)
+
+# Builds better-sqlite3-multiple-ciphers prebuilds for an Electron target that upstream
+# has not shipped yet (e.g. Electron 42 / ABI 146 / V8 14), applying the V8-14 source fix.
+# Produces electron-v<abi>-<platform>-<arch> tarballs as workflow artifacts; download them
+# and add to packages/better-sqlite3/. macOS is built/verified locally, so this covers
+# Linux + Windows by default.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'better-sqlite3-multiple-ciphers version'
+        required: true
+        default: '12.10.0'
+      electron:
+        description: 'Electron target version (e.g. 42.2.0)'
+        required: true
+        default: '42.2.0'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-24.04, platform: linux, arch: x64 }
+          - { os: ubuntu-24.04-arm, platform: linux, arch: arm64 }
+          - { os: windows-latest, platform: win32, arch: x64 }
+          - { os: windows-11-arm, platform: win32, arch: arm64 }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout (for patch + verify scripts)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Fetch and extract source
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          curl -sSL "https://registry.npmjs.org/better-sqlite3-multiple-ciphers/-/better-sqlite3-multiple-ciphers-${VERSION}.tgz" -o src.tgz
+          tar xzf src.tgz
+          # tarball extracts to ./package
+
+      - name: Apply V8 14 patch
+        shell: bash
+        run: node .github/scripts/patch-bsmc-v8-14.js package
+
+      - name: Install build tooling
+        shell: bash
+        working-directory: package
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      - name: Build prebuild
+        shell: bash
+        working-directory: package
+        env:
+          ELECTRON: ${{ inputs.electron }}
+          ARCH: ${{ matrix.arch }}
+        run: npx prebuild -r electron -t "$ELECTRON" --arch "$ARCH" --include-regex 'better_sqlite3.node$'
+
+      - name: Install Electron for verification
+        shell: bash
+        working-directory: package
+        env:
+          ELECTRON: ${{ inputs.electron }}
+        run: npm install --no-save --no-audit --no-fund "electron@$ELECTRON"
+
+      - name: Verify under Electron (Linux)
+        if: matrix.platform == 'linux'
+        shell: bash
+        working-directory: package
+        run: |
+          sudo apt-get update && sudo apt-get install -y xvfb
+          out=$(xvfb-run -a ./node_modules/.bin/electron ../.github/scripts/verify-bsmc.js "$PWD" 2>&1) || true
+          echo "$out"
+          echo "$out" | grep -q "VERIFY_OK" || { echo "verification failed"; exit 1; }
+
+      - name: Verify under Electron (Windows)
+        if: matrix.platform == 'win32'
+        shell: bash
+        working-directory: package
+        run: |
+          out=$(./node_modules/.bin/electron ../.github/scripts/verify-bsmc.js "$PWD" 2>&1) || true
+          echo "$out"
+          echo "$out" | grep -q "VERIFY_OK" || { echo "verification failed"; exit 1; }
+
+      - name: Upload prebuild artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bsmc-${{ matrix.platform }}-${{ matrix.arch }}
+          path: package/prebuilds/*.tar.gz
+          if-no-files-found: error


### PR DESCRIPTION
Adds a reusable workflow + scripts to build better-sqlite3-multiple-ciphers for an Electron target upstream hasn't shipped yet (Electron 42 / ABI 146 / V8 14), applying the WiseLibs #1475 V8-14 fix and verifying each binary under Electron before upload.

- `.github/scripts/patch-bsmc-v8-14.js` - the 3-file V8-14 source patch (idempotent, anchor-checked)
- `.github/scripts/verify-bsmc.js` - loads the built binary under Electron, runs queries + cipher path
- `.github/workflows/build-better-sqlite3-electron.yml` - matrix: linux x64/arm64, win32 x64/arm64; inputs: version (12.10.0), electron (42.2.0); uploads tarballs as artifacts

macOS is built/verified locally (PR #1124). Needs merging to main before it can be dispatched (workflow_dispatch requires the file on the default branch). After merge I'll trigger it, then download the artifacts into a binaries PR.

Same fix family as DBC-1791 / #1123. Actions are SHA-pinned.