### PR TITLE
ci: fix electron prebuild workflow (verified green on Linux)

### DIFF
--- a/.github/scripts/patch-bsmc-v8-14.js
+++ b/.github/scripts/patch-bsmc-v8-14.js
@@ -80,6 +80,29 @@ replaceOnce(
 	}
 }
 
+// 4) Windows/MSVC only: V8 14's cppgc/heap.h uses __builtin_frame_address(0) (a Clang/GCC
+//    builtin) unconditionally; MSVC lacks it. Shim it to _AddressOfReturnAddress() (the MSVC
+//    stack-address intrinsic V8 itself uses elsewhere) before any V8 header is included. The
+//    only compiled TU is src/better_sqlite3.cpp, so prepending there covers everything.
+//    Guarded to MSVC-non-clang, so it is a no-op on the macOS/Linux (clang/gcc) builds.
+{
+	const file = path.join(pkg, 'src/better_sqlite3.cpp');
+	const marker = '/* dbcode: MSVC __builtin_frame_address shim */';
+	let c = fs.readFileSync(file, 'utf8');
+	if (c.includes(marker)) {
+		console.log('SKIP (already patched) src/better_sqlite3.cpp: MSVC frame-address shim');
+	} else {
+		const shim =
+			marker +
+			'\n#if defined(_MSC_VER) && !defined(__clang__)\n' +
+			'#include <intrin.h>\n' +
+			'#define __builtin_frame_address(x) _AddressOfReturnAddress()\n' +
+			'#endif\n';
+		fs.writeFileSync(file, shim + c);
+		console.log('OK src/better_sqlite3.cpp: MSVC frame-address shim');
+	}
+}
+
 if (failed) {
 	process.exit(1);
 }

--- a/.github/scripts/verify-bsmc.js
+++ b/.github/scripts/verify-bsmc.js
@@ -17,12 +17,13 @@ app.whenReady().then(() => {
 	let encFile;
 	try {
 		const pkgDir = process.argv[2] || process.cwd();
-		const mod = require(pkgDir);
-		const Database = typeof mod === 'function' ? mod : mod && (mod.default || mod.Database);
+		// require(pkgDir) mis-resolves to <repo>/package.json (Node's LOAD_AS_FILE matches the
+		// sibling package.json before the package/ directory), so resolve via the package manifest.
+		const pkgJson = require(path.join(pkgDir, 'package.json'));
+		const entry = require(path.join(pkgDir, pkgJson.main || 'lib/index.js'));
+		const Database = typeof entry === 'function' ? entry : entry && (entry.default || entry.Database);
 		if (typeof Database !== 'function') {
-			throw new Error(
-				`export is not a constructor: typeof=${typeof mod} keys=${mod && Object.keys(mod)} path=${pkgDir}`,
-			);
+			throw new Error(`export is not a constructor: typeof=${typeof entry} path=${pkgDir}`);
 		}
 
 		const db = new Database(':memory:');

--- a/.github/scripts/verify-bsmc.js
+++ b/.github/scripts/verify-bsmc.js
@@ -16,8 +16,14 @@ app.commandLine.appendSwitch('no-sandbox');
 app.whenReady().then(() => {
 	let encFile;
 	try {
-		const pkgDir = process.argv[2];
-		const Database = require(pkgDir);
+		const pkgDir = process.argv[2] || process.cwd();
+		const mod = require(pkgDir);
+		const Database = typeof mod === 'function' ? mod : mod && (mod.default || mod.Database);
+		if (typeof Database !== 'function') {
+			throw new Error(
+				`export is not a constructor: typeof=${typeof mod} keys=${mod && Object.keys(mod)} path=${pkgDir}`,
+			);
+		}
 
 		const db = new Database(':memory:');
 		db.exec('CREATE TABLE t(a INTEGER, b TEXT)');

--- a/.github/workflows/build-better-sqlite3-electron.yml
+++ b/.github/workflows/build-better-sqlite3-electron.yml
@@ -64,6 +64,15 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: npx prebuild -r electron -t "$ELECTRON" --arch "$ARCH" --include-regex 'better_sqlite3.node$'
 
+      # Upload before verify so a successful build always yields an artifact,
+      # even if the Electron launch in CI is flaky.
+      - name: Upload prebuild artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bsmc-${{ matrix.platform }}-${{ matrix.arch }}
+          path: package/prebuilds/*.tar.gz
+          if-no-files-found: error
+
       - name: Install Electron for verification
         shell: bash
         working-directory: package
@@ -76,7 +85,11 @@ jobs:
         shell: bash
         working-directory: package
         run: |
-          sudo apt-get update && sudo apt-get install -y xvfb
+          sudo apt-get update
+          sudo apt-get install -y xvfb libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 \
+            libcups2t64 libgtk-3-0t64 libgbm1 libasound2t64 libxshmfence1 libdrm2 \
+            libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
+            libpango-1.0-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 || true
           out=$(xvfb-run -a ./node_modules/.bin/electron ../.github/scripts/verify-bsmc.js "$PWD" 2>&1) || true
           echo "$out"
           echo "$out" | grep -q "VERIFY_OK" || { echo "verification failed"; exit 1; }
@@ -89,10 +102,3 @@ jobs:
           out=$(./node_modules/.bin/electron ../.github/scripts/verify-bsmc.js "$PWD" 2>&1) || true
           echo "$out"
           echo "$out" | grep -q "VERIFY_OK" || { echo "verification failed"; exit 1; }
-
-      - name: Upload prebuild artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bsmc-${{ matrix.platform }}-${{ matrix.arch }}
-          path: package/prebuilds/*.tar.gz
-          if-no-files-found: error

--- a/.github/workflows/build-better-sqlite3-electron.yml
+++ b/.github/workflows/build-better-sqlite3-electron.yml
@@ -84,6 +84,8 @@ jobs:
         if: matrix.platform == 'linux'
         shell: bash
         working-directory: package
+        env:
+          ELECTRON_DISABLE_SANDBOX: '1'
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 \


### PR DESCRIPTION
Fixes to the build workflow from #1125 so it actually produces + verifies binaries (validated: Linux x64/arm64 green under Electron 42.2.0):

- Upload artifact right after build (a successful build always yields an artifact).
- Install Electron runtime deps + `ELECTRON_DISABLE_SANDBOX=1` for the Linux verify (CI has no root-owned chrome-sandbox).
- Resolve the better-sqlite3 entry via its manifest in verify-bsmc.js (require(pkgDir) was matching the repo-root `package.json` via Node's LOAD_AS_FILE rule).

Windows jobs still fail at the build step (V8 14 / MSVC) - separate.