### PR TITLE
collect: commit only packages prebuilds

### DIFF
--- a/.github/workflows/build-better-sqlite3-node.yml
+++ b/.github/workflows/build-better-sqlite3-node.yml
@@ -204,6 +204,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Commit only the staged prebuilds, never the downloaded artifacts/ working dir.
+          add-paths: packages/better-sqlite3
           commit-message: "Build Node ${{ inputs.node }} prebuilds for better-sqlite3-multiple-ciphers ${{ inputs.version }}"
           title: "Build Node ${{ inputs.node }} prebuilds for better-sqlite3-multiple-ciphers ${{ inputs.version }}"
           body: |


### PR DESCRIPTION
Restricts the prebuilds PR to packages/better-sqlite3 so the downloaded artifacts dir is no longer committed