### PR TITLE
Add antivirus gates, attest after they pass

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,6 +5,11 @@ name: Build and publish
 # repository; it is checked out with a read-only deploy key and discarded with the
 # runner.
 #
+# This workflow validates nothing about the source. Release-readiness checks, such
+# as translation catalog assembly, live in the private release workflow and run
+# before it pushes the bump and dispatches here. This builds the commit it is
+# handed.
+#
 # actions/attest-build-provenance signs only this repo's own OIDC claims, so the
 # dispatch payload's source commit never reaches the attestation directly. We
 # bind the two ourselves: the "Stamp build provenance" step writes the source
@@ -94,9 +99,6 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
-
-      - name: Verify release translation catalogs
-        run: pnpm exec tsx scripts/translation-fragments.ts verify-release
 
       - name: Package
         run: pnpm dlx @vscode/vsce@3.9.2 package --no-dependencies --no-git-tag-version --no-update-package-json --allow-package-secrets privatekey

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,8 +1,9 @@
 name: Build and publish
 
-# Builds the DBCode extension from the private source at an exact commit, attests
-# it, and publishes. The source is never written to this repository; it is checked
-# out with a read-only deploy key and discarded with the runner.
+# Builds the DBCode extension from the private source at an exact commit, scans it
+# for malware, attests it, and publishes. The source is never written to this
+# repository; it is checked out with a read-only deploy key and discarded with the
+# runner.
 #
 # actions/attest-build-provenance signs only this repo's own OIDC claims, so the
 # dispatch payload's source commit never reaches the attestation directly. We
@@ -11,6 +12,11 @@ name: Build and publish
 # packaging, so it becomes part of the vsix the attestation signs. The binding
 # is indirect, through the artifact digest, but it is what makes the claimed
 # commit tamper-evident.
+#
+# Attestation runs last, in its own job, only after both antivirus gates pass.
+# Sigstore transparency-log entries are permanent and public, so we sign only
+# artifacts that cleared every gate, rather than logging attestations for builds
+# that were rejected and never shipped.
 #
 # DO NOT ADD A pull_request OR pull_request_target TRIGGER.
 #
@@ -33,8 +39,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
-      attestations: write
     env:
       HUSKY: '0'
     steps:
@@ -99,13 +103,102 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=6144
 
-      - name: Attest
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: '*.vsix'
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: extension
           path: '*.vsix'
           if-no-files-found: error
+
+  # Antivirus gate - ClamAV scan of the packaged vsix. Fails the release if
+  # ClamAV flags anything in the artifact a customer's AV could block. The mangled
+  # obfuscator config plus vendor XOR neutralization must keep this clean; a hit stops the
+  # release for investigation rather than allowlisting the pattern.
+  scan-clamav:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
+    needs: [build]
+    if: success()
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: extension
+      - name: ClamAV scan
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y clamav >/dev/null
+          # apt auto-starts the clamav-freshclam daemon, which locks the freshclam log;
+          # stop it so a manual signature download can run.
+          sudo systemctl stop clamav-freshclam || true
+          sudo freshclam
+          vsix=$(find . -iname '*.vsix' | head -1)
+          echo "Scanning $vsix"
+          mkdir -p extracted && unzip -q "$vsix" -d extracted
+          # clamscan exits 1 on detection, 0 clean, 2 on error - any non-zero fails the job.
+          clamscan -r --detect-pua=yes --heuristic-alerts=yes \
+            --alert-broken=yes --alert-encrypted=yes --alert-macros=yes \
+            --scan-pe=yes --scan-html=yes --scan-archive=yes --bytecode=yes \
+            --max-filesize=400M --max-scansize=2000M --max-files=200000 \
+            extracted
+
+  # Antivirus gate - Windows Defender scan of the packaged vsix. Defender does
+  # not currently flag our obfuscated build (proven in CI), but it is kept as a release
+  # canary: if a future change trips Defender, this blocks the publish rather than shipping
+  # a build that Windows users' real-time protection would quarantine.
+  scan-defender:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    permissions: {}
+    needs: [build]
+    if: success()
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: extension
+      - name: Windows Defender scan
+        shell: pwsh
+        run: |
+          $mp = "$env:ProgramFiles\Windows Defender\MpCmdRun.exe"
+          # Maximize detection: cloud-delivered protection (MAPS) at the most aggressive
+          # level plus PUA protection, with current signatures.
+          try {
+            Set-MpPreference -MAPSReporting Advanced
+            Set-MpPreference -SubmitSamplesConsent SendAllSamples
+            Set-MpPreference -CloudBlockLevel High
+            Set-MpPreference -CloudExtendedTimeout 50
+            Set-MpPreference -PUAProtection Enabled
+          } catch { Write-Host "MpPreference config: $($_.Exception.Message)" }
+          & $mp -SignatureUpdate 2>&1 | Out-Host
+          $vsix = (Get-ChildItem *.vsix)[0].FullName
+          Copy-Item $vsix pkg.zip
+          Expand-Archive pkg.zip -DestinationPath extracted -Force
+          & $mp -Scan -ScanType 3 -File "$PWD\extracted" -DisableRemediation 2>&1 | Out-Host
+          $code = $LASTEXITCODE
+          Write-Host "Defender tree scan exit code: $code (2 = threat found, 0 = clean)"
+          if ($code -eq 2) {
+            Get-MpThreat | Format-List | Out-Host
+            Write-Error "Windows Defender flagged the packaged extension."
+            exit 1
+          }
+
+  # Attestation happens only after both antivirus gates pass, and only here: Sigstore
+  # transparency-log entries are permanent and public, so we sign artifacts that cleared
+  # every gate rather than logging attestations for builds that were rejected and never
+  # shipped. Downloads the same "extension" artifact the scans just cleared and attests
+  # that exact file - actions/upload-artifact and actions/download-artifact round-trip
+  # file bytes unchanged, so the digest this signs matches the one the scans checked.
+  attest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      attestations: write
+    needs: [build, scan-clamav, scan-defender]
+    if: success()
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: extension
+      - name: Attest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: '*.vsix'


### PR DESCRIPTION
Adds the two antivirus gates the private release pipeline already runs, and moves attestation to after they pass.

```
build          ubuntu    package the vsix, upload artifact
scan-clamav    ubuntu    needs: build
scan-defender  windows   needs: build
attest         ubuntu    needs: all three
```

`scan-defender` is a separate job because it runs `MpCmdRun.exe` and needs `windows-latest`. Both scans depend only on `build`, so they run concurrently.

Attestation moved out of `build` because Sigstore transparency log entries are permanent and public. Signing only what cleared every gate avoids logging attestations for builds that were rejected and never shipped.

Also drops the translation catalog check. That verifies the release assembly ran, which is a property of the source commit, so it belongs in the private release workflow and now runs there before the bump is pushed. Keeping it here only made this workflow fail whenever translation fragments happened to be pending.

Scan commands are carried over unchanged from the private pipeline. Still publishes nothing.
