### PR TITLE
Give the sqlite3 build jobs an explicit token scope

### DIFF
--- a/.github/workflows/build-better-sqlite3-electron.yml
+++ b/.github/workflows/build-better-sqlite3-electron.yml
@@ -18,6 +18,11 @@ on:
         required: true
         default: '42.2.0'
 
+# Default for every job. The build jobs only read the repo and upload artifacts,
+# so they need nothing more. A job that needs write declares its own block.
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-better-sqlite3-node.yml
+++ b/.github/workflows/build-better-sqlite3-node.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: '20'
 
+# Default for every job. The build jobs only read the repo and upload artifacts,
+# so they need nothing more. `collect` overrides this with what it actually needs.
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     # glibc builds run in a Debian container (glibc 2.31, <= the VS Code remote-server floor).


### PR DESCRIPTION
Closes the four open CodeQL alerts, all `actions/missing-workflow-permissions`.

Four jobs declared no `permissions:` block, so each inherited the repository default token scope. All four only check out the repo and upload artifacts, so a workflow-level `contents: read` covers them.

`collect` already declares `contents: write` and `pull-requests: write`, which is why it was not flagged, and it keeps that override.

Both workflows are `workflow_dispatch` only. No behaviour change.
