### PR TITLE
ci: add dependabot config for action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# Keeps the SHA pins in .github/workflows current. Dependabot rewrites both the
+# sha and the trailing "# vX.Y.Z" comment, so pins stay readable.
+#
+# Actions only. The root package.json is generated from the private source repo
+# on build and release, so it must never be updated from here.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Ignore releases younger than a week (supply-chain quarantine, matching
+    # the minimum-release-age we use for npm).
+    cooldown:
+      default-days: 7
+    # One PR for all action bumps rather than one per action.
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Adds `.github/dependabot.yml` so Dependabot keeps the SHA pins in `.github/workflows` up to date (it rewrites the sha and the trailing version comment).

- Actions only. The root `package.json` comes from the private source repo on build and release, so it is deliberately not covered.
- Weekly, grouped into a single PR.
- 7-day cooldown before a new release is proposed.