### PR TITLE
pnpm 11 + pnpm/setup

### DIFF
--- a/.github/release-tools/package.json
+++ b/.github/release-tools/package.json
@@ -2,7 +2,7 @@
 	"name": "dbcode-release-tools",
 	"private": true,
 	"description": "Publishing tools, pinned by the lockfile. Not at the repo root: the extension's package.json is synced there.",
-	"packageManager": "pnpm@10.33.4",
+	"packageManager": "pnpm@11.25.0",
 	"devDependencies": {
 		"@vscode/vsce": "3.9.2",
 		"ovsx": "1.0.2"

--- a/.github/release-tools/pnpm-workspace.yaml
+++ b/.github/release-tools/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# pnpm 11: build scripts need an explicit allow/deny; neither is needed here.
+allowBuilds:
+  "@vscode/vsce-sign": false
+  keytar: false

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -104,7 +104,10 @@ jobs:
             '{sourceRepository: $sourceRepository, sourceCommit: $sourceCommit, version: $version, buildWorkflowRun: $buildWorkflowRun}' \
             > build-provenance.json
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      # version read from the checked-out package.json's `packageManager` field
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: 'false'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -354,12 +357,12 @@ jobs:
         with:
           sparse-checkout: .github/release-tools
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        # Only .github/release-tools is checked out, so action-setup cannot find a
-        # package.json at the root - pin explicitly (keep in sync with its
-        # packageManager field).
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        # Only .github/release-tools is checked out, so there is no package.json at
+        # the root - pin explicitly (keep in sync with its packageManager field).
         with:
-          version: 10.33.4
+          version: 11.25.0
+          install: 'false'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.12'
@@ -396,9 +399,12 @@ jobs:
         with:
           sparse-checkout: .github/release-tools
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        # Only .github/release-tools is checked out, so there is no package.json at
+        # the root - pin explicitly (keep in sync with its packageManager field).
         with:
-          version: 10.33.4
+          version: 11.25.0
+          install: 'false'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.12'


### PR DESCRIPTION
Runner 2.337.0 ships a broken bundled node that pnpm/action-setup depends on. Swap all three sites to the official pnpm/setup action (SHA-pinned, install disabled), bump release-tools to pnpm 11.25.0, and add the allowBuilds denials pnpm 11 requires. Lockfiles unchanged; release-tools frozen install verified locally under pnpm 11.