### PR TITLE
Use actions/attest directly

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,8 +5,8 @@ name: Build and publish
 # the runner. Release-readiness checks belong to the private release workflow; this
 # builds the commit it is handed.
 #
-# attest-build-provenance signs only this repo's OIDC claims, so the source commit
-# never reaches the attestation directly. "Stamp build provenance" writes it into
+# actions/attest (provenance mode) signs only this repo's OIDC claims, so the source
+# commit never reaches the attestation directly. "Stamp build provenance" writes it into
 # build-provenance.json before packaging, so the signed digest covers it.
 #
 # DO NOT ADD A pull_request OR pull_request_target TRIGGER. This repo is public and
@@ -236,7 +236,9 @@ jobs:
         with:
           name: extension
       - name: Attest
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        # No predicate inputs: actions/attest defaults to generating SLSA build
+        # provenance, same as the attest-build-provenance wrapper it replaces.
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: '*.vsix'
 


### PR DESCRIPTION
attest-build-provenance is now a thin wrapper and its docs point new implementations at actions/attest. With no predicate inputs it generates the same SLSA build provenance, so the attestation and the documented verify command are unchanged. Supersedes #1217.